### PR TITLE
Fix Cheat Engine Selecting Wrong ROBLOX Process

### DIFF
--- a/executor.lua
+++ b/executor.lua
@@ -204,6 +204,8 @@ for _, task in pairs(tasklist) do
     if name:match("roblox") and name:match("player") then
         if primary_process == nil then
             primary_process = task
+        elseif primary_process.MemoryUsage > task.MemoryUsage then
+            secondary_process = task
         elseif primary_process.MemoryUsage < task.MemoryUsage then
             secondary_process = primary_process
             primary_process = task

--- a/executor.lua
+++ b/executor.lua
@@ -193,6 +193,28 @@ function TaskList:FetchAll() return self:_Fetch(TASKLIST_GLOBAL_COMMAND) end
 function TaskList:GetCollection() return self._collection end
 
 -- #endregion TaskList
+--#region open-process
+print("[Tasklist] Generating list of processes...")
+local tasklist = TaskList:Fetch("roblox") or error("roblox process was not found running.")
+local primary_process = nil
+local secondary_process = nil
+
+for _, task in pairs(tasklist) do
+    local name = task.Name:lower()
+    if name:match("roblox") and name:match("player") then
+        if primary_process == nil then
+            primary_process = task
+        elseif primary_process.MemoryUsage < task.MemoryUsage then
+            secondary_process = primary_process
+            primary_process = task
+        end
+    end
+end
+
+assert(primary_process, "process was not found running.") -- kinda unnecessary
+print("[Tasklist] Opening process...")
+openProcess(primary_process.ProcessId)
+--#endregion
 --#endregion
 
 
@@ -211,6 +233,8 @@ load_api("api_celua.lua")();
 
 -- import my memory utilities
 load_api("api_util.lua")();
+
+util.init(primary_process.ProcessId)
 
 rbx = {};
 rbx.offsets = {};


### PR DESCRIPTION
The issue is that Cheat Engine sometimes selects the secondary ROBLOX process, which is not the main game client and causes the script to fail.

I created a library to help iterate through the process list and fetch the memory that they occupy, and using this information the necessary process is selected and opened.